### PR TITLE
Feature/header and footer for pdf

### DIFF
--- a/Classes/Options/ModuleOptions.php
+++ b/Classes/Options/ModuleOptions.php
@@ -54,8 +54,9 @@ class ModuleOptions implements \TYPO3\CMS\Core\SingletonInterface {
      * @throws \TYPO3\CMS\Extbase\Configuration\Exception\InvalidConfigurationTypeException
      */
     public function initializeObject() {
-        if ($this->options = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS, 'web2pdf', 'settings')) {
+        $configuration = $this->configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
 
+        if ($this->options = array_merge($configuration['plugin.']['tx_web2pdf.']['settings.'], $configuration['plugin.']['tx_web2pdf.']['view.'])) {
             if (is_array($this->options['pdfPregSearch']) && is_array($this->options['pdfPregReplace'])) {
                 $this->mergeReplaceConfiguration($this->options['pdfPregSearch'], $this->options['pdfPregReplace'], \Mittwald\Web2pdf\View\PdfView::PREG_REPLACEMENT_KEY);
                 unset($this->options['pdfPregSearch'], $this->options['pdfPregReplace']);

--- a/Classes/Service/PdfRenderService.php
+++ b/Classes/Service/PdfRenderService.php
@@ -88,9 +88,18 @@ class PdfRenderService {
 
             return $this->view->renderHtmlOutput(
                     $this->frontendController->content,
-                    $this->frontendController->page['title']
+                    $this->getPageTitle()
             );
         }
+    }
+
+    /**
+     * @return string
+     */
+    protected function getPageTitle() {
+        return $this->frontendController->altPageTitle ?
+                $this->frontendController->altPageTitle :
+                $this->frontendController->indexedDocTitle;
     }
 
     /**

--- a/Classes/View/PdfView.php
+++ b/Classes/View/PdfView.php
@@ -25,6 +25,7 @@
 
 namespace Mittwald\Web2pdf\View;
 
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
@@ -79,6 +80,8 @@ class PdfView {
 
         $content = $this->replaceStrings($content);
         $pdf = $this->getPdfObject();
+        $pdf->SetHTMLHeader($this->getPartial('Header', array('title' => $pageTitle)));
+        $pdf->SetHTMLFooter($this->getPartial('Footer', array('title' => $pageTitle)));
         $pdf->WriteHTML($content);
         $pdf->Output($filePath, 'F');
 
@@ -138,7 +141,22 @@ class PdfView {
         $pdf = $this->objectManager->get('mPDF', '', $pageFormat . '-' . $pageOrientation);
         $pdf->SetMargins($leftMargin, $rightMargin, $topMargin);
         $pdf->CSSselectMedia = $styleSheet;
-        $pdf->AddPage();
+
         return $pdf;
     }
+
+    /**
+     * @param $templateName
+     * @return string
+     */
+    protected function getPartial($templateName, $arguments = array()) {
+        /* @var $partial \TYPO3\CMS\Fluid\View\StandaloneView */
+        $partial = $this->objectManager->get('TYPO3\CMS\Fluid\View\StandaloneView');
+        $partial->setLayoutRootPath(GeneralUtility::getFileAbsFileName($this->options->getLayoutRootPath()));
+        $partial->setPartialRootPath(GeneralUtility::getFileAbsFileName($this->options->getPartialRootPath()));
+        $partial->setTemplatePathAndFilename(GeneralUtility::getFileAbsFileName($this->options->getPartialRootPath()) . 'Pdf/' . ucfirst($templateName) . '.html');
+        $partial->assign('data', $arguments);
+        return $partial->render();
+    }
+
 }

--- a/Classes/View/PdfView.php
+++ b/Classes/View/PdfView.php
@@ -80,8 +80,16 @@ class PdfView {
 
         $content = $this->replaceStrings($content);
         $pdf = $this->getPdfObject();
-        $pdf->SetHTMLHeader($this->getPartial('Header', array('title' => $pageTitle)));
-        $pdf->SetHTMLFooter($this->getPartial('Footer', array('title' => $pageTitle)));
+
+        // Add Header
+        if ($this->options->getUseCustomHeader()) {
+            $pdf->SetHTMLHeader($this->getPartial('Header', array('title' => $pageTitle)));
+        }
+        // Add Footer
+        if ($this->options->getUseCustomFooter()) {
+            $pdf->SetHTMLFooter($this->getPartial('Footer', array('title' => $pageTitle)));
+        }
+
         $pdf->WriteHTML($content);
         $pdf->Output($filePath, 'F');
 

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -24,5 +24,10 @@ plugin.tx_web2pdf {
 		pdfTopMargin = 15
 		# cat=plugin.tx_web2pdf/pdf/6; type=options[LLL:EXT:web2pdf/Resources/Private/Language/locallang.xlf:constants.pdf.styleSheet.print=print,LLL:EXT:web2pdf/Resources/Private/Language/locallang.xlf:constants.pdf.styleSheet.screen=screen]; label=LLL:EXT:web2pdf/Resources/Private/Language/locallang.xlf:constants.pdf.styleSheet
 		pdfStyleSheet = print
+		# cat=plugin.tx_web2pdf/pdf/8; type=boolean; label=LLL:EXT:web2pdf/Resources/Private/Language/locallang.xlf:constants.pdf.useCustomFooter
+		useCustomFooter = 0
+		# cat=plugin.tx_web2pdf/pdf/8; type=boolean; label=LLL:EXT:web2pdf/Resources/Private/Language/locallang.xlf:constants.pdf.useCustomHeader
+		useCustomHeader = 0
+
 	}
 }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -12,6 +12,8 @@ plugin.tx_web2pdf {
 		pdfRightMargin = {$plugin.tx_web2pdf.settings.pdfRightMargin}
 		pdfTopMargin = {$plugin.tx_web2pdf.settings.pdfTopMargin}
 		pdfStyleSheet = {$plugin.tx_web2pdf.settings.pdfStyleSheet}
+		useCustomHeader = {$plugin.tx_web2pdf.settings.useCustomHeader}
+		useCustomFooter = {$plugin.tx_web2pdf.settings.useCustomFooter}
 
 		pdfPregSearch {
 			1 =

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -24,6 +24,7 @@ TypoScript Reference
 --------------------
 
 * PDF Configuration can be set in constant editor or TypoScript
+* Example Footer and Header HTML files can be found in partialRootPath/Pdf/Header.html (with pagenum and date)
 ::
 
 	plugin.web2pdf.settings {
@@ -36,6 +37,10 @@ TypoScript Reference
 		pdfTopMargin = {$plugin.tx_web2pdf.settings.pdfTopMargin}
 		# which stylesheet to use: print or screen stylesheet
 		pdfStyleSheet = {$plugin.tx_web2pdf.settings.pdfStyleSheet}
+		# use header partial in plugin.web2pdf.view.partialRootPath/Pdf/Header.html
+		useCustomHeader = 0
+		# use footer partial in plugin.web2pdf.view.partialRootPath/Pdf/Footer.html
+		useCustomHeader = 0
 	}
 
 Replacements
@@ -62,6 +67,7 @@ Can be set via TypoScript using following options:
 		pdfStrReplace {
 			1 =
 		}
+
 	}
 Example: Replace `Hello` with `Good Night`
 ::

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -58,6 +58,12 @@
             <trans-unit id="constants.pdf.styleSheet.screen">
                 <source>screen</source>
             </trans-unit>
+            <trans-unit id="constants.pdf.useCustomFooter">
+                <source>Use custom fluid footer</source>
+            </trans-unit>
+            <trans-unit id="constants.pdf.useCustomHeader">
+                <source>Use custom fluid header</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Partials/Pdf/Footer.html
+++ b/Resources/Private/Partials/Pdf/Footer.html
@@ -1,0 +1,12 @@
+<table width="100%"
+	   style="vertical-align: bottom; font-family: serif; font-size: 8pt; color: #000000; font-weight: bold; font-style: italic;">
+	<tr>
+		<td width="33%"><span style="font-weight: bold; font-style: italic;"><f:format.date>now</f:format.date></span></td>
+		<td width="33%" align="center" style="font-weight: bold; font-style: italic;">
+			<f:alias map="{ocb: '{', ccb: '}'}">
+				{ocb}PAGENO{ccb}/{ocb}nbpg{ccb}
+			</f:alias>
+		</td>
+		<td width="33%" style="text-align: right; ">{data.title}</td>
+	</tr>
+</table>

--- a/Resources/Private/Partials/Pdf/Header.html
+++ b/Resources/Private/Partials/Pdf/Header.html
@@ -1,0 +1,12 @@
+<table width="100%"
+	   style="vertical-align: bottom; font-family: serif; font-size: 8pt; color: #000000; font-weight: bold; font-style: italic;">
+	<tr>
+		<td width="33%"><span style="font-weight: bold; font-style: italic;"><f:format.date>now</f:format.date></span></td>
+		<td width="33%" align="center" style="font-weight: bold; font-style: italic;">
+			<f:alias map="{ocb: '{', ccb: '}'}">
+				{ocb}PAGENO{ccb}/{ocb}nbpg{ccb}
+			</f:alias>
+		</td>
+		<td width="33%" style="text-align: right; ">{data.title}</td>
+	</tr>
+</table>


### PR DESCRIPTION
Improved solution.
Now everybody is able to use own footer and header in pdf file.
In default fluid html files you can use pagenum and default fluid viewhelper for header and footer.

No need of option showPageNumber which was introduced yesterday.