### PR TITLE
#16 [HOTFIX] Add generatePdfLink to non-cacheable actions

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -34,7 +34,9 @@ TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
         array(
                 'Pdf' => 'generatePdfLink',
         ),
-        array()
+        array(
+                'Pdf' => 'generatePdfLink',
+        )
 );
 
 // Add default real url config


### PR DESCRIPTION
Weird bug, but could trace the error.
Seems like the ``configurationManager`` of TYPO3 does not load whole configuration. 

If you ``Clear all caches`` in ``Installation Tool`` configuration should be reloaded and everything works fine. With this hotfix the plugin is not cached at all and is inserted as ``USER_INT`` object. 

Working on another fix, but for now it should solve the problem but could cause performance issues.