### PR TITLE
Develop

### DIFF
--- a/Classes/Utility/PdfLinkUtility.php
+++ b/Classes/Utility/PdfLinkUtility.php
@@ -48,7 +48,6 @@ class PdfLinkUtility {
         $currentSiteUri = (preg_match('/^\//', $tmpSiteUri)) ? $tmpSiteUri : '/' . $tmpSiteUri;
         $currentHost = $this->getHost();
         $regex = '/<a(.*?)href="([^#"]*?)#([a-zA-Z0-9]+)"/';
-        
         $replacedContent = preg_replace_callback($regex, function ($hit) use ($currentSiteUri, $currentHost) {
             if (strpos($hit[0], $currentSiteUri) !== false
                 || strpos(htmlentities($hit[0]), $currentSiteUri) !== false

--- a/Classes/Utility/PdfLinkUtility.php
+++ b/Classes/Utility/PdfLinkUtility.php
@@ -47,15 +47,14 @@ class PdfLinkUtility {
         $tmpSiteUri = $this->getSiteUri();
         $currentSiteUri = (preg_match('/^\//', $tmpSiteUri)) ? $tmpSiteUri : '/' . $tmpSiteUri;
         $currentHost = $this->getHost();
-        $regex = '/<a(.*?)href\s*=\s*[\'\"](.*?)#(.*?)[\'\"]/';
+        $regex = '/<a(.*?)href="([^#"]*?)(#([a-zA-Z0-9]+))?"/';
         $replacedContent = preg_replace_callback($regex, function ($hit) use ($currentSiteUri, $currentHost) {
-            if ((!empty($hit[3]) && preg_match('/[a-zA-Z]/', $hit[3]))
-                    && (strpos($hit[0], $currentSiteUri) !== false
-                            || strpos(htmlentities($hit[0]), $currentSiteUri) !== false
-                            || strpos($hit[0], $currentHost . $currentSiteUri) !== false
-                            || strpos(htmlentities($hit[0]), $currentHost . $currentSiteUri) !== false)
+            if (strpos($hit[0], $currentSiteUri) !== false
+                || strpos(htmlentities($hit[0]), $currentSiteUri) !== false
+                || strpos($hit[0], $currentHost . $currentSiteUri) !== false
+                || strpos(htmlentities($hit[0]), $currentHost . $currentSiteUri) !== false
             ) {
-                return '<a' . $hit[1] . 'href="#' . $hit[3] . '"';
+                return '<a' . $hit[1] . 'href="#' . $hit[4] . '"';
             }
             return $hit[0];
         }, $content);

--- a/Classes/Utility/PdfLinkUtility.php
+++ b/Classes/Utility/PdfLinkUtility.php
@@ -47,14 +47,15 @@ class PdfLinkUtility {
         $tmpSiteUri = $this->getSiteUri();
         $currentSiteUri = (preg_match('/^\//', $tmpSiteUri)) ? $tmpSiteUri : '/' . $tmpSiteUri;
         $currentHost = $this->getHost();
-        $regex = '/<a(.*?)href="([^#"]*?)(#([a-zA-Z0-9]+))?"/';
+        $regex = '/<a(.*?)href="([^#"]*?)#([a-zA-Z0-9]+)"/';
+        
         $replacedContent = preg_replace_callback($regex, function ($hit) use ($currentSiteUri, $currentHost) {
             if (strpos($hit[0], $currentSiteUri) !== false
                 || strpos(htmlentities($hit[0]), $currentSiteUri) !== false
                 || strpos($hit[0], $currentHost . $currentSiteUri) !== false
                 || strpos(htmlentities($hit[0]), $currentHost . $currentSiteUri) !== false
             ) {
-                return '<a' . $hit[1] . 'href="#' . $hit[4] . '"';
+                return '<a' . $hit[1] . 'href="#' . $hit[3] . '"';
             }
             return $hit[0];
         }, $content);


### PR DESCRIPTION
reduces regex matching to one operation with non-greedy quantifiers expecting non empty anchors, thereby reducing cost of two state machines and number of callbacks