### PR TITLE
[FEATURE] Option to add extra stylesheet

### DIFF
--- a/Classes/View/PdfView.php
+++ b/Classes/View/PdfView.php
@@ -184,6 +184,10 @@ class PdfView
             unset($pdf->CSSselectMedia);
         }
 
+        if($this->options->getPdfAdditionalStyleSheet()) {
+            $pdf->WriteHTML(GeneralUtility::getUrl(GeneralUtility::getFileAbsFileName($this->options->getPdfAdditionalStyleSheet())), 1);
+        }
+        
         return $pdf;
     }
 


### PR DESCRIPTION
Sometimes it's not clear why the HTML-embedded stylesheets are not being loaded by mpdf. Or maybe you need a specific stylesheet just for PDF generation. This option makes it possible to forcefully add that extra stylesheet.