### PR TITLE
add margin-header and margin-footer configuration

### DIFF
--- a/Classes/View/PdfView.php
+++ b/Classes/View/PdfView.php
@@ -159,6 +159,8 @@ class PdfView
         $rightMargin = ($this->options->getPdfRightMargin()) ? $this->options->getPdfRightMargin() : '15';
         $bottomMargin = ($this->options->getPdfBottomMargin()) ? $this->options->getPdfBottomMargin() : '15';
         $topMargin = ($this->options->getPdfTopMargin()) ? $this->options->getPdfTopMargin() : '15';
+        $headerMargin = ($this->options->getPdfHeaderMargin()) ? $this->options->getPdfHeaderMargin() : '9';
+        $footerMargin = ($this->options->getPdfFooterMargin()) ? $this->options->getPdfFooterMargin() : '9';
         $styleSheet = ($this->options->getPdfStyleSheet()) ? $this->options->getPdfStyleSheet() : 'print';
 
         /* @var $pdf Mpdf */
@@ -170,6 +172,8 @@ class PdfView
                 'margin_right' => $rightMargin,
                 'margin_top' => $topMargin,
                 'margin_bottom' => $bottomMargin,
+                'margin_header' => $headerMargin,
+                'margin_footer' => $footerMargin,
                 'orientation' => $pageOrientation,
                 'tempDir' => PATH_site . 'typo3temp',
                 'fontDir' => ExtensionManagementUtility::extPath('web2pdf') . 'Resources/Public/Fonts',

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -32,6 +32,10 @@ plugin.tx_web2pdf {
 		useCustomFooter = 0
 		# cat=plugin.tx_web2pdf/pdf/10; type=boolean; label=LLL:EXT:web2pdf/Resources/Private/Language/locallang.xlf:constants.pdf.useCustomHeader
 		useCustomHeader = 0
+		# cat=plugin.tx_web2pdf/pdf/11; type=int+; label=LLL:EXT:web2pdf/Resources/Private/Language/locallang.xlf:constants.pdf.headerMargin
+		pdfHeaderMargin = 9
+		# cat=plugin.tx_web2pdf/pdf/12; type=int+; label=LLL:EXT:web2pdf/Resources/Private/Language/locallang.xlf:constants.pdf.footerMargin
+		pdfFooterMargin = 9
 
 	}
 }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -12,6 +12,8 @@ plugin.tx_web2pdf {
         pdfRightMargin = {$plugin.tx_web2pdf.settings.pdfRightMargin}
         pdfTopMargin = {$plugin.tx_web2pdf.settings.pdfTopMargin}
         pdfBottomMargin = {$plugin.tx_web2pdf.settings.pdfBottomMargin}
+        pdfHeaderMargin = {$plugin.tx_web2pdf.settings.pdfHeaderMargin}
+        pdfFooterMargin = {$plugin.tx_web2pdf.settings.pdfFooterMargin}
         pdfStyleSheet = {$plugin.tx_web2pdf.settings.pdfStyleSheet}
         pdfDestination = {$plugin.tx_web2pdf.settings.pdfDestination}
         useCustomHeader = {$plugin.tx_web2pdf.settings.useCustomHeader}

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -37,6 +37,12 @@
             <trans-unit id="constants.pdf.leftMargin">
                 <source>Left margin</source>
             </trans-unit>
+            <trans-unit id="constants.pdf.headerMargin">
+                <source>Header margin</source>
+            </trans-unit>
+            <trans-unit id="constants.pdf.footerMargin">
+                <source>Footer margin</source>
+            </trans-unit>
             <trans-unit id="constants.pdf.fontSize">
                 <source>Default font size</source>
             </trans-unit>


### PR DESCRIPTION
I added the margin-header and margin-footer variables.

From MPDF documentation:
margin-header = distance in mm from top of page to start of header
margin-footer = distance in mm from bottom of page to bottom of footer