### PR TITLE
Add extension key to composer.json to mitigate composer warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
   "extra": {
     "typo3/cms": {
       "cms-package-dir": "{$vendor-dir}/typo3/cms",
+      "extension-key": "web2pdf",
       "web-dir": "public"
     }
   }


### PR DESCRIPTION
Beginning with version 3.1.0 of `typo3/cms-composer-installers` the package emits a warning:

> TYPO3 Extension Package "mittwald/web2pdf", does not define extension key in composer.json.
> Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)

This patch mitigates the problem.